### PR TITLE
do not fetch google font inherit

### DIFF
--- a/includes/cool_timline_template.php
+++ b/includes/cool_timline_template.php
@@ -379,7 +379,7 @@ if (!class_exists('CoolTimeline_Template')) {
 			$selected_fonts = array_unique($selected_fonts);
 			// If it is a Google font, go ahead and call the function to enqueue it
 			foreach ( $selected_fonts as $font ) {
-				if ($font) {
+				if ($font != 'inherit') {
 			
 			// Certain Google fonts need slight tweaks in order to load properly
 			// Like our friend "Raleway"


### PR DESCRIPTION
If font "inherit" is used in "Typography Settings" we don't need to include that from google.
