### PR TITLE
Return value instead of echoing it in `admin_footer_text` callback

### DIFF
--- a/admin/codestar-framework/classes/admin-options.class.php
+++ b/admin/codestar-framework/classes/admin-options.class.php
@@ -496,7 +496,7 @@ if ( ! class_exists( 'CSF_Options' ) ) {
     }
 
     public function add_admin_footer_text() {
-      echo wp_kses_post( $this->args['footer_credit'] );
+      return wp_kses_post( $this->args['footer_credit'] );
     }
 
     public function error_check( $sections, $err = '' ) {


### PR DESCRIPTION
Filter hook callbacks must `return` their value, and not directly `echo` it.

This otherwise creates problem for other plugins (like mine), as they then get passed `null` as the filter hook variable.